### PR TITLE
Default config providers and other providers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,15 @@ version '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
 }
 
 dependencies {
+    implementation 'org.yaml:snakeyaml:1.33'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
 }
 
 test {

--- a/src/main/java/com/gremlin/FailureFlagSDKGlobalConfiguration.java
+++ b/src/main/java/com/gremlin/FailureFlagSDKGlobalConfiguration.java
@@ -1,0 +1,23 @@
+package com.gremlin;
+
+public class FailureFlagSDKGlobalConfiguration {
+  public static final String IDENTIFIER = "IDENTIFIER";
+  public static final String REGION = "REGION";
+  public static final String ZONE = "ZONE";
+  public static final String STAGE = "STAGE";
+  public static final String VERSION = "VERSION";
+  public static final String BUILD = "BUILD";
+  public static final String TAGS = "TAGS";
+  public static final String TEAM_ID = "TEAM_ID";
+  public static final String TEAM_SECRET = "TEAM_SECRET";
+  public static final String TEAM_CERTIFICATE = "TEAM_CERTIFICATE";
+  public static final String TEAM_KEY = "TEAM_KEY";
+
+  //System properties
+  public static final String JAVA_VENDOR = "java.vendor";
+  public static final String JAVA_VENDOR_URL = "java.vendor.url";
+  public static final String JAVA_VERSION = "java.version";
+  public static final String OS_ARCH = "os.arch";
+  public static final String OS_NAME = "os.name";
+  public static final String OS_VERSION = "os.version";
+}

--- a/src/main/java/com/gremlin/providers/DefaultFailureFlagAgentProviderChain.java
+++ b/src/main/java/com/gremlin/providers/DefaultFailureFlagAgentProviderChain.java
@@ -1,0 +1,45 @@
+package com.gremlin.providers;
+
+import com.gremlin.GremlinAgent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultFailureFlagAgentProviderChain implements FailureFlagAgentProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      DefaultFailureFlagAgentProviderChain.class);
+
+  private static final DefaultFailureFlagAgentProviderChain INSTANCE = new DefaultFailureFlagAgentProviderChain();
+  private final List<FailureFlagAgentProvider> failureFlagAgentProviderList =
+      new ArrayList<>();
+
+  public DefaultFailureFlagAgentProviderChain() {
+    failureFlagAgentProviderList.addAll(
+        Arrays.asList(new InfrastructureAgentConfigFileAgentProvider(),
+            new FailureFlagConfigFileAgentProvider(), new SystemPropertiesAgentProvider(),
+            new EnvironmentVariableAgentProvider()));
+  }
+
+  public static DefaultFailureFlagAgentProviderChain getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public GremlinAgent.Builder getGremlinAgentBuilder() {
+    logger.info("Using default Failure Flag provider chain");
+    GremlinAgent.Builder originalBuilder = new GremlinAgent.Builder();
+    for (FailureFlagAgentProvider provider : failureFlagAgentProviderList) {
+      try {
+        GremlinAgent.Builder newAgentBuilder = provider.getGremlinAgentBuilder();
+        originalBuilder.overrideWithNew(newAgentBuilder);
+      }  catch (Exception e) {
+        logger.info(e.getMessage());
+      }
+    }
+    return originalBuilder;
+  }
+
+}

--- a/src/main/java/com/gremlin/providers/EnvironmentVariableAgentProvider.java
+++ b/src/main/java/com/gremlin/providers/EnvironmentVariableAgentProvider.java
@@ -1,0 +1,43 @@
+package com.gremlin.providers;
+
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.BUILD;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.IDENTIFIER;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.REGION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.STAGE;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TAGS;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_CERTIFICATE;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_ID;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_KEY;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_SECRET;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.VERSION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.ZONE;
+
+import com.gremlin.GremlinAgent;
+import com.gremlin.utils.AgentProviderUtils;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class EnvironmentVariableAgentProvider implements FailureFlagAgentProvider {
+  private static final Logger logger = LoggerFactory.getLogger(EnvironmentVariableAgentProvider.class);
+
+  @Override
+  public GremlinAgent.Builder getGremlinAgentBuilder() {
+    logger.info("Using environment variables");
+    String identifier = System.getenv(IDENTIFIER);
+    String region = System.getenv(REGION);
+    String zone = System.getenv(ZONE);
+    String stage = System.getenv(STAGE);
+    String version = System.getenv(VERSION);
+    String build = System.getenv(BUILD);
+    Map<String, String> tags = AgentProviderUtils.getTags(System.getenv(TAGS));
+    String teamId = System.getenv(TEAM_ID);
+    String teamSecret = System.getenv(TEAM_SECRET);
+    String teamCertificate = System.getenv(TEAM_CERTIFICATE);
+    String teamKey = System.getenv(TEAM_KEY);
+
+    GremlinAgent.Builder builder = AgentProviderUtils.getBuilder(identifier, region, zone, stage, version, build, teamId, teamSecret, tags, teamCertificate, teamKey);
+    return builder;
+  }
+}

--- a/src/main/java/com/gremlin/providers/FailureFlagAgentProvider.java
+++ b/src/main/java/com/gremlin/providers/FailureFlagAgentProvider.java
@@ -1,0 +1,7 @@
+package com.gremlin.providers;
+
+import com.gremlin.GremlinAgent;
+
+public interface FailureFlagAgentProvider {
+  GremlinAgent.Builder getGremlinAgentBuilder();
+}

--- a/src/main/java/com/gremlin/providers/FailureFlagConfigFileAgentProvider.java
+++ b/src/main/java/com/gremlin/providers/FailureFlagConfigFileAgentProvider.java
@@ -1,0 +1,58 @@
+package com.gremlin.providers;
+
+import com.gremlin.GremlinAgent;
+import com.gremlin.GremlinAgent.Builder;
+import com.gremlin.utils.AgentProviderUtils;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class FailureFlagConfigFileAgentProvider implements FailureFlagAgentProvider {
+  private static final Logger logger = LoggerFactory.getLogger(FailureFlagConfigFileAgentProvider.class);
+  private String fileLocation;
+
+  public FailureFlagConfigFileAgentProvider() {
+    this(System.getProperty("user.home") == null ? "" : System.getProperty("user.home") + "/.gremlin/config.yaml");
+  }
+
+  public FailureFlagConfigFileAgentProvider(String configFileLocation) {
+    this.fileLocation = configFileLocation;
+  }
+
+
+  @Override
+  public GremlinAgent.Builder getGremlinAgentBuilder() {
+    logger.info("Using failure flag config file at {}", fileLocation);
+    Yaml yaml = new Yaml(new Constructor(FailureFlagYamlConfig.class));
+    try {
+      InputStream inputStream = new FileInputStream(fileLocation);
+      FailureFlagYamlConfig failureFlagYamlConfig = yaml.load(inputStream);
+      GremlinAgent.Builder builder = AgentProviderUtils.getBuilder(failureFlagYamlConfig.identifier, failureFlagYamlConfig.region, failureFlagYamlConfig.zone, failureFlagYamlConfig.stage, failureFlagYamlConfig.version, failureFlagYamlConfig.build,
+          failureFlagYamlConfig.teamId, failureFlagYamlConfig.teamSecret, failureFlagYamlConfig.tags, failureFlagYamlConfig.teamCertificate, failureFlagYamlConfig.teamKey);
+
+      return builder;
+    } catch (FileNotFoundException e) {
+      return new Builder();
+    }
+  }
+
+  private static class FailureFlagYamlConfig {
+    public String identifier;
+    public String region;
+    public String zone;
+    public String stage;
+    public String version;
+    public String build;
+    public Map<String, String> tags;
+    public String teamId;
+    public String teamSecret;
+    public String teamCertificate;
+    public String teamKey;
+  }
+
+}

--- a/src/main/java/com/gremlin/providers/InfrastructureAgentConfigFileAgentProvider.java
+++ b/src/main/java/com/gremlin/providers/InfrastructureAgentConfigFileAgentProvider.java
@@ -1,0 +1,62 @@
+package com.gremlin.providers;
+
+import com.gremlin.GremlinAgent;
+import com.gremlin.GremlinAgent.Builder;
+import com.gremlin.utils.AgentProviderUtils;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class InfrastructureAgentConfigFileAgentProvider implements FailureFlagAgentProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      InfrastructureAgentConfigFileAgentProvider.class);
+  private String fileLocation;
+
+  public InfrastructureAgentConfigFileAgentProvider() {
+    this("/etc/gremlin/config.yaml");
+  }
+
+  public InfrastructureAgentConfigFileAgentProvider(String configFileLocation) {
+    this.fileLocation = configFileLocation;
+  }
+
+  @Override
+  public GremlinAgent.Builder getGremlinAgentBuilder() {
+    logger.info("Using infrastructure agent config file at {}", fileLocation);
+    Yaml yaml = new Yaml(new Constructor(InfrastructureAgentYamlConfig.class));
+    try {
+      InputStream inputStream = new FileInputStream(fileLocation);
+      InfrastructureAgentYamlConfig infraYamlConfig = yaml.load(inputStream);
+      GremlinAgent.Builder builder = AgentProviderUtils.getBuilder(infraYamlConfig.identifier, null,
+          null, null, null, null,
+          infraYamlConfig.team_id, infraYamlConfig.team_secret, infraYamlConfig.tags,
+          infraYamlConfig.team_certificate, infraYamlConfig.team_private_key);
+
+      return builder;
+    } catch (FileNotFoundException e) {
+      return new Builder();
+
+    }
+  }
+
+  private static class InfrastructureAgentYamlConfig {
+
+    public String identifier;
+    public String team_id;
+    public Map<String, String> tags;
+    public String team_secret;
+    public String team_certificate;
+    public String team_private_key;
+    public String https_proxy;
+    public String ssl_cert_file;
+    public boolean push_metrics;
+    public boolean collect_processes;
+  }
+
+}

--- a/src/main/java/com/gremlin/providers/SystemPropertiesAgentProvider.java
+++ b/src/main/java/com/gremlin/providers/SystemPropertiesAgentProvider.java
@@ -1,0 +1,92 @@
+package com.gremlin.providers;
+
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.BUILD;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.IDENTIFIER;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.JAVA_VENDOR;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.JAVA_VENDOR_URL;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.JAVA_VERSION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.OS_ARCH;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.OS_NAME;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.OS_VERSION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.REGION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.STAGE;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TAGS;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_CERTIFICATE;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_ID;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_KEY;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.TEAM_SECRET;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.VERSION;
+import static com.gremlin.FailureFlagSDKGlobalConfiguration.ZONE;
+
+import com.gremlin.GremlinAgent;
+import com.gremlin.GremlinAgent.Builder;
+import com.gremlin.utils.AgentProviderUtils;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SystemPropertiesAgentProvider implements FailureFlagAgentProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      SystemPropertiesAgentProvider.class);
+
+  private String fileLocation;
+
+  public SystemPropertiesAgentProvider() {
+  }
+
+  public SystemPropertiesAgentProvider(String propertiesFile) {
+    this.fileLocation = propertiesFile;
+  }
+
+  @Override
+  public GremlinAgent.Builder getGremlinAgentBuilder() {
+    logger.info("Using system properties {}", fileLocation == null ? "" : "at " + fileLocation);
+    try {
+      if (fileLocation != null && !fileLocation.isEmpty()) {
+        FileInputStream propFile =
+            new FileInputStream(fileLocation);
+        Properties p =
+            new Properties(System.getProperties());
+        p.load(propFile);
+
+        // set the system properties
+        System.setProperties(p);
+      }
+
+      String identifier = System.getProperty(IDENTIFIER);
+      String region = System.getProperty(REGION);
+      String zone = System.getProperty(ZONE);
+      String stage = System.getProperty(STAGE);
+      String version = System.getProperty(VERSION);
+      String build = System.getProperty(BUILD);
+      Map<String, String> tags = AgentProviderUtils.getTags(System.getProperty(TAGS));
+      String teamId = System.getProperty(TEAM_ID);
+      String teamSecret = System.getProperty(TEAM_SECRET);
+      String teamCertificate = System.getProperty(TEAM_CERTIFICATE);
+      String teamKey = System.getProperty(TEAM_KEY);
+
+      GremlinAgent.Builder builder = AgentProviderUtils.getBuilder(identifier, region, zone, stage,
+          version, build, teamId, teamSecret, tags, teamCertificate, teamKey);
+
+      builder.withJavaVendor(System.getProperty(JAVA_VENDOR))
+          .withJavaVendorUrl(System.getProperty(JAVA_VENDOR_URL))
+          .withJavaVersion(System.getProperty(JAVA_VERSION))
+          .withOsArch(System.getProperty(OS_ARCH))
+          .withOsName(System.getProperty(OS_NAME))
+          .withOsVersion(System.getProperty(OS_VERSION));
+
+      return builder;
+
+    } catch (FileNotFoundException e) {
+      return new Builder();
+    } catch (IOException e) {
+      return new Builder();
+    }
+  }
+
+}

--- a/src/main/java/com/gremlin/utils/AgentProviderUtils.java
+++ b/src/main/java/com/gremlin/utils/AgentProviderUtils.java
@@ -1,0 +1,66 @@
+package com.gremlin.utils;
+
+import com.gremlin.GremlinAgent;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class AgentProviderUtils {
+
+  public static Map<String, String> getTags(String tags) {
+    Map<String, String> tagsMap = new HashMap<>();
+    if (tags != null) {
+      String[] keyPairs = tags.split(",");
+      if (keyPairs.length > 0) {
+        Arrays.asList(keyPairs).forEach(kp -> {
+          String[] keyPair = kp.trim().split("=");
+          if (keyPair.length == 2) {
+            tagsMap.put(keyPair[0], keyPair[1]);
+          }
+        });
+      }
+    }
+    return tagsMap;
+  }
+
+  private static void populateBuilderWithTags(Map<String, String> tags,
+      GremlinAgent.Builder builder) {
+    if (tags != null) {
+      for (Entry keyValue : tags.entrySet()) {
+        builder.withTagPair(keyValue.getKey().toString(), keyValue.getValue().toString());
+      }
+    }
+  }
+
+  private static void populateBuilderWithTeamCertAndKey(String teamCertificate, String teamKey,
+      GremlinAgent.Builder builder) {
+    if (teamCertificate != null) {
+      builder.withTeamCertificate(teamCertificate.getBytes(StandardCharsets.UTF_8));
+    }
+    if (teamKey != null) {
+      builder.withTeamKey(teamKey.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  public static GremlinAgent.Builder getBuilder(String identifier, String region, String zone,
+      String stage, String version, String build, String teamId, String teamSecret, Map<String, String> tags,
+      String teamCertificate, String teamKey) {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withIdentifier(identifier)
+        .withRegion(region)
+        .withZone(zone)
+        .withStage(stage)
+        .withVersion(version)
+        .withBuild(build)
+        .withTeamId(teamId)
+        .withTeamSecret(teamSecret);
+
+    populateBuilderWithTags(tags, builder);
+    populateBuilderWithTeamCertAndKey(teamCertificate, teamKey, builder);
+    return builder;
+  }
+
+
+}

--- a/src/test/java/com/gremlin/GremlinAgentTest.java
+++ b/src/test/java/com/gremlin/GremlinAgentTest.java
@@ -1,8 +1,18 @@
 package com.gremlin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.gremlin.providers.EnvironmentVariableAgentProvider;
+import com.gremlin.providers.FailureFlagConfigFileAgentProvider;
+import com.gremlin.providers.InfrastructureAgentConfigFileAgentProvider;
+import java.io.File;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -18,7 +28,9 @@ public class GremlinAgentTest {
   private static final String TAG_1_KEY = "key1";
   private static final String TAG_1_VALUE = "value1";
   private static final String TAG_2_KEY = "key2";
-  private static final String TAG_2_VALUE = "zone";
+  private static final String TAG_2_VALUE = "value2";
+  private static final String TAG_3_KEY = "key3";
+  private static final String TAG_3_VALUE = "value3";
   private static final String TEAM_ID = "teamId1";
   private static final String TEAM_SECRET = "teamSecret";
   private static final byte[] TEAM_CERT = new byte[]{(byte) 0xea, 0x3a, 0x69, 0x10, (byte) 0xa2,
@@ -27,6 +39,9 @@ public class GremlinAgentTest {
       0x30, 0x30};
   private static final byte[] TEAM_KEY = new byte[]{(byte) 0xd8, 0x08, 0x00, 0x2b,
       0x30, 0x30, (byte) 0x9d};
+
+  private static final String IDENTIFIER_NEW = "identifierNew";
+  private static final String REGION_NEW = "regionNew";
 
   @Test
   public void buildGremlinAgent_throwsUnSupportedOperationException() {
@@ -108,5 +123,192 @@ public class GremlinAgentTest {
 
     assertEquals(false, gremlin.isDependencyTestActive("dep1", TestType.LATENCY));
     assertEquals(false, gremlin.isDependencyTestActive("dep2", TestType.UNAVAILABLE));
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenIdentifierNotPresentAndDefaultProviderChain_returnsFalseOnValidate() {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withRegion(REGION)
+        .withZone(ZONE)
+        .withStage(STAGE)
+        .withVersion(VERSION)
+        .withBuild(BUILD)
+        .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+        .withTagPair(TAG_2_KEY, TAG_2_VALUE)
+        .withTeamId(TEAM_ID)
+        .withTeamSecret(TEAM_SECRET)
+        .withTeamCertificate(TEAM_CERT)
+        .withTeamKey(TEAM_KEY);
+
+    assertFalse(builder.isValidationPassed());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenTeamIdNotPresentAndDefaultProviderChain_returnsFalseOnValidate() {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withIdentifier(IDENTIFIER)
+        .withRegion(REGION)
+        .withZone(ZONE)
+        .withStage(STAGE)
+        .withVersion(VERSION)
+        .withBuild(BUILD)
+        .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+        .withTagPair(TAG_2_KEY, TAG_2_VALUE)
+        .withTeamSecret(TEAM_SECRET)
+        .withTeamCertificate(TEAM_CERT)
+        .withTeamKey(TEAM_KEY);
+
+    assertFalse(builder.isValidationPassed());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenTeamCredsNotPresentAndDefaultProviderChain_returnsFalseOnValidate() {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withIdentifier(IDENTIFIER)
+        .withRegion(REGION)
+        .withZone(ZONE)
+        .withStage(STAGE)
+        .withVersion(VERSION)
+        .withBuild(BUILD)
+        .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+        .withTagPair(TAG_2_KEY, TAG_2_VALUE);
+
+    assertFalse(builder.isValidationPassed());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenTeamCertPresentButNoKeyPresentNotPresentAndDefaultProviderChain_returnsFalseOnValidate() {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withIdentifier(IDENTIFIER)
+        .withRegion(REGION)
+        .withZone(ZONE)
+        .withStage(STAGE)
+        .withVersion(VERSION)
+        .withBuild(BUILD)
+        .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+        .withTagPair(TAG_2_KEY, TAG_2_VALUE)
+        .withTeamCertificate(TEAM_CERT);
+
+    assertFalse(builder.isValidationPassed());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenTeamKeyPresentButNoCertPresentNotPresentAndDefaultProviderChain_returnsFalseOnValidate() {
+    GremlinAgent.Builder builder = new GremlinAgent.Builder()
+        .withIdentifier(IDENTIFIER)
+        .withRegion(REGION)
+        .withZone(ZONE)
+        .withStage(STAGE)
+        .withVersion(VERSION)
+        .withBuild(BUILD)
+        .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+        .withTagPair(TAG_2_KEY, TAG_2_VALUE)
+        .withTeamKey(TEAM_KEY);
+
+    assertFalse(builder.isValidationPassed());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenEnvironmentAgentProvider_usesEnvironmentAndOverridesTheRest() {
+    EnvironmentVariableAgentProvider environmentVariableAgentProvider = mock(
+        EnvironmentVariableAgentProvider.class);
+    when(environmentVariableAgentProvider.getGremlinAgentBuilder()).thenReturn(
+        new GremlinAgent.Builder()
+            .withIdentifier(IDENTIFIER)
+            .withRegion(REGION)
+            .withZone(ZONE)
+            .withStage(STAGE)
+            .withVersion(VERSION)
+            .withBuild(BUILD)
+            .withTagPair(TAG_1_KEY, TAG_1_VALUE)
+            .withTagPair(TAG_2_KEY, TAG_2_VALUE)
+            .withTeamId(TEAM_ID)
+            .withTeamSecret(TEAM_SECRET)
+            .withTeamCertificate(TEAM_CERT)
+            .withTeamKey(TEAM_KEY));
+
+    GremlinAgent agent = new GremlinAgent.Builder()
+        .withFailureFlagAgentProvider(environmentVariableAgentProvider)
+        .withIdentifier(IDENTIFIER_NEW)
+        .withRegion(REGION_NEW)
+        .withTagPair(TAG_3_KEY, TAG_3_VALUE)
+        .buildMock(false);
+
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put(TAG_1_KEY, TAG_1_VALUE);
+    expectedTags.put(TAG_2_KEY, TAG_2_VALUE);
+    expectedTags.put(TAG_3_KEY, TAG_3_VALUE);
+
+    assertEquals(IDENTIFIER_NEW, agent.getIdentifier());
+    assertEquals(REGION_NEW, agent.getRegion());
+    assertEquals(ZONE, agent.getZone());
+    assertEquals(STAGE, agent.getStage());
+    assertEquals(VERSION, agent.getVersion());
+    assertEquals(BUILD, agent.getBuild());
+    assertEquals(expectedTags, agent.getTags());
+    assertEquals(TEAM_ID, agent.getTeamId());
+    assertEquals(TEAM_SECRET, agent.getTeamSecret());
+    assertEquals(TEAM_CERT, agent.getTeamCertificate());
+    assertEquals(TEAM_KEY, agent.getTeamKey());
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenInfraAgentConfigFileProvider() throws URISyntaxException {
+    File file = new File("src/test/resources/test-infra-config.yaml");
+    String absolutePath = file.getAbsolutePath();
+
+    GremlinAgent agent = new GremlinAgent.Builder()
+        .withFailureFlagAgentProvider(new InfrastructureAgentConfigFileAgentProvider(absolutePath))
+        .withIdentifier(IDENTIFIER_NEW)
+        .withRegion(REGION_NEW)
+        .withTagPair(TAG_3_KEY, TAG_3_VALUE)
+        .buildMock(false);
+
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put("service", "pet-store");
+    expectedTags.put("interface", "http");
+    expectedTags.put(TAG_3_KEY, TAG_3_VALUE);
+
+    assertEquals(IDENTIFIER_NEW, agent.getIdentifier());
+    assertEquals(REGION_NEW, agent.getRegion());
+    assertNull(agent.getZone());
+    assertNull(agent.getStage());
+    assertNull(agent.getVersion());
+    assertNull(agent.getBuild());
+    assertEquals(expectedTags, agent.getTags());
+    assertEquals("11111111-1111-1111-1111-111111111111", agent.getTeamId());
+    assertNull(agent.getTeamSecret());
+    assertNotNull(agent.getTeamCertificate());
+    assertNotNull(agent.getTeamKey());
+
+  }
+
+  @Test
+  public void buildMockGremlinAgent_whenFailureFlagConfigFileProvider_usesFailureFlagConfigAndOverridesTheRest() throws URISyntaxException {
+    File file = new File("src/test/resources/test-failure-flag-config.yaml");
+    String absolutePath = file.getAbsolutePath();
+
+    GremlinAgent agent = new GremlinAgent.Builder()
+        .withFailureFlagAgentProvider(new FailureFlagConfigFileAgentProvider(absolutePath))
+        .withIdentifier(IDENTIFIER_NEW)
+        .withRegion(REGION_NEW)
+        .withTagPair(TAG_3_KEY, TAG_3_VALUE)
+        .buildMock(false);
+
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put("app", "control");
+    expectedTags.put(TAG_3_KEY, TAG_3_VALUE);
+
+    assertEquals(IDENTIFIER_NEW, agent.getIdentifier());
+    assertEquals(REGION_NEW, agent.getRegion());
+    assertEquals("us-west-1a", agent.getZone());
+    assertNull(agent.getStage());
+    assertNull(agent.getVersion());
+    assertEquals("2.3.0", agent.getBuild());
+    assertEquals(expectedTags, agent.getTags());
+    assertEquals("otherteam", agent.getTeamId());
+    assertEquals("somesecret", agent.getTeamSecret());
+    assertNull(agent.getTeamCertificate());
+    assertNull(agent.getTeamKey());
   }
 }

--- a/src/test/resources/test-failure-flag-config.yaml
+++ b/src/test/resources/test-failure-flag-config.yaml
@@ -1,0 +1,7 @@
+region: us-west-1
+zone: us-west-1a
+build: 2.3.0
+teamId: otherteam
+teamSecret: somesecret
+tags:
+  app: control

--- a/src/test/resources/test-infra-config.yaml
+++ b/src/test/resources/test-infra-config.yaml
@@ -1,0 +1,58 @@
+## Gremlin Identifier; uniquely identifies this machine with Gremlin
+## (can also set with GREMLIN_IDENTIFIER environment variable)
+identifier: gremlin-01
+
+## Gremlin Team Id; you can find this value at https://app.gremlin.com/settings/teams
+## (can also be set with GREMLIN_TEAM_ID environment variable)
+team_id: 11111111-1111-1111-1111-111111111111
+
+## Gremlin Client Tags; Tag your machine with key-value pairs that help you target this machine during attacks
+## (can also set with GREMLIN_CLIENT_TAGS environment variable)
+tags:
+  service: pet-store
+  interface: http
+
+## Gremlin Team Secret, should not be set when using `team_certificate`+`team_private_key`
+## (can also set with GREMLIN_TEAM_SECRET environment variable)
+#team_secret: 11111111-1111-1111-1111-111111111111
+
+## Gremlin Team Certificate, should not be set when using `team_secret`.
+## Paste certificate content here or a paths to the file (prefixed with `file://`)
+## (can also set with GREMLIN_TEAM_CERTIFICATE_OR_FILE environment variable)
+team_certificate: |
+  -----BEGIN CERTIFICATE-----
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  1111111111111111111111111111111111111111111111111111111111111111
+  11111111111111111111111111111111111111111111111111==
+  -----END CERTIFICATE-----
+
+## Gremlin Team Certificate, should not be set when using `team_secret`.
+## Paste certificate content here or a paths to the file (prefixed with `file://`)
+## (can also set with GREMLIN_TEAM_PRIVATE_KEY_OR_FILE environment variable)
+team_private_key: file:///var/lib/gremlin/key.pem
+
+## HTTPS Proxy, set this when routing outbound Gremlin HTTPS traffic through a proxy
+## (can also set with HTTPS_PROXY or https_proxy environment variables)
+https_proxy: https://localhost:3128
+
+## SSL CERT FILE, set this when using a https proxy with a self-signed certificate
+## Paste certificate content here or a paths to the file (prefixed with `file://`)
+## (can also set with SSL_CERT_FILE environment variable)
+ssl_cert_file: file:///var/lib/gremlin/proxy_cert.pem
+
+## Push Metrics, tell Gremlin whether to send system metrics to the control plane for charting the impact of attacks in
+## real time. Metrics are only collected during active attacks, and only metrics relevant to the attack are collected.
+## defaults to `true`
+## (can also set with PUSH_METRICS environment variable)
+push_metrics: true
+
+## Collect Process Data, data about running processes is sent to Gremlin for service discovery.
+## defaults to `true` as of Gremlin Linux Agent 2.25.0
+collect_processes: true


### PR DESCRIPTION
Background: 
The configuration providers should load configuration in the following order:
1. Environment variables
2. Java system properties
3. The Failure Flags configuration file - typically located at ~/.gremlin/config.yaml. The adopter should be able to override the location of this file by setting the environment variable, GREMLIN_FAILURE_FLAGS_CONFIG_FILE
4. The Gremlin infrastructure agent configuration file - typically located at /etc/gremlin/config.yaml
Finally, the adopter must be able to manually override the auto-configuration at the code level with “wither” functions as defined in 

Change:

- Add the above providers
- Unit tests for the providers