### PR TITLE
Java 8 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.gremlin'
-version '1.0'
+version '1.1'
 
 repositories {
     mavenCentral()
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = "com.gremlin"
             artifactId = "failure-flags-java"
-            version = "1.0"
+            version = "1.1"
             from components.java
 
             pom {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ repositories {
 }
 
 java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
     withSourcesJar()
     withJavadocJar()
 }

--- a/src/test/java/com/gremlin/failureflags/FailureFlagsTest.java
+++ b/src/test/java/com/gremlin/failureflags/FailureFlagsTest.java
@@ -64,7 +64,7 @@ public class FailureFlagsTest {
             (experiments) -> { fail("default behavior must not be called"); });
     failureFlags.enabled = true;
     failureFlags.invoke(
-            new FailureFlag("test-1", Map.of("method", "POST"), true),
+            new FailureFlag("test-1", new HashMap<String,String>(){{put("method", "POST");}}, true),
             (experiments) -> { fail("custom behavior must not be called"); });
   }
 


### PR DESCRIPTION
This change retrofits the codebase for compatibility with Java 1.8 and its SDK. Specifically this change replaces a dependency on the Java 11 `HttpClient` with the much older `HttpUrlConnection`.