### PR TITLE
[FFException] Handle message behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = "com.gremlin"
             artifactId = "failure-flags-java"
-            version = "1.1"
+            version = "1.2"
             from components.java
 
             pom {

--- a/src/main/java/com/gremlin/failureflags/behaviors/Exception.java
+++ b/src/main/java/com/gremlin/failureflags/behaviors/Exception.java
@@ -3,6 +3,8 @@ package com.gremlin.failureflags.behaviors;
 import com.gremlin.failureflags.Behavior;
 import com.gremlin.failureflags.FailureFlagException;
 import com.gremlin.failureflags.Experiment;
+import java.util.Map;
+
 /**
  * Exception processes <code>exception</code> properties in experiment effects.
  *
@@ -20,9 +22,20 @@ public class Exception implements Behavior {
         continue;
       }
       Object failureFlagException = e.getEffect().get("exception");
+
+      // For backwards compatibility with earlier versions of the SDK
       if (failureFlagException instanceof String) {
         throw new FailureFlagException("Exception injected by failure flag: " + failureFlagException);
       }
+
+      // Standard behavior for exception FF Experiments:
+      if (failureFlagException instanceof Map) {
+        Object message = ((Map)failureFlagException).get("message");
+        if (message instanceof String) {
+          throw new FailureFlagException("Exception injected by failure flag: " + message);
+        }
+      }
+
     }
   }
 }


### PR DESCRIPTION
**Background**
In other implementations exception behavior is handled as either:

```
{ "exception": "YOUR STRING HERE" }
```
OR
```
{ 
  "exception": {
    "message": "YOUR STRING HERE"
  }
}
```

but the current Java SDK only supports the former

see:
 * https://github.com/gremlin/failure-flags-net/blob/main/sdk/src/FailureFlags/Behaviors/Exception.cs#L28-L45
 * https://github.com/gremlin/failure-flags-python/blob/main/src/failureflags/__init__.py#L232-L249

**Change**
Support both patterns